### PR TITLE
Adds hash of install script to cache key

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -30,13 +30,38 @@ runs:
   using: "composite"
   steps:
 
+    - name: Download TeX Live distribution and create hash (Windows)
+      if: runner.os == 'Windows'
+      shell: powershell
+      run: |
+        ## Check into temporary folder
+        Set-Location -Path ${{ runner.temp }}
+        ## Download installer
+        Invoke-WebRequest http://mirror.ctan.org/systems/texlive/tlnet/install-tl.zip -OutFile install-tl.zip
+        ## Generate hash and save it
+        $fileHash = (Get-FileHash install-tl.zip).Hash
+        $envString = "texlive_install_hash=" + $fileHash
+        echo $envString | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
+
+    - name: Download TeX Live distribution and create hash (Linux or macOS)
+      if: runner.os != 'Windows' && steps.cache-texlive.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
+        # Install TeX Live distribution (Linux or macOS)
+        ## Check into temporary folder
+        cd ${{ runner.temp }}
+        ## Download installer
+        wget --quiet http://mirror.ctan.org/systems/texlive/tlnet/install-tl-unx.tar.gz
+        ## Generate hash and save it
+        echo "texlive_install_hash=$(shasum -a 256 install-tl-unx.tar.gz | cut -f 1 -d " ")" >> $GITHUB_ENV
+
     - name: Cache TeX Live installation
       uses: actions/cache@v2
       id: cache-texlive
       if: inputs.cache-enabled == 'true'
       with:
         path: ${{ inputs.installation-path }}
-        key: ${{ inputs.cache-key }}-${{ hashFiles(inputs.profile-path, inputs.packages-path) }}
+        key: ${{ inputs.cache-key }}-${{ env.texlive_install_hash }}-${{ hashFiles(inputs.profile-path, inputs.packages-path) }}
         restore-keys: ${{ inputs.cache-key }}-
 
     - name: Install TeX Live distribution (Windows)
@@ -49,8 +74,6 @@ runs:
         # Install TeX Live distribution (Windows)
         ## Check into temporary folder
         Set-Location -Path ${{ runner.temp }}
-        ## Download installer
-        Invoke-WebRequest http://mirror.ctan.org/systems/texlive/tlnet/install-tl.zip -OutFile install-tl.zip
         ## Unpack installer
         Expand-Archive -Path install-tl.zip -DestinationPath .
         ## Check into unpacked installer folder
@@ -67,8 +90,6 @@ runs:
         # Install TeX Live distribution (Linux or macOS)
         ## Check into temporary folder
         cd ${{ runner.temp }}
-        ## Download installer
-        wget --quiet http://mirror.ctan.org/systems/texlive/tlnet/install-tl-unx.tar.gz
         ## Unpack installer
         tar -xzf install-tl-unx.tar.gz
         ## Check into unpacked installer folder


### PR DESCRIPTION
It closes #9

I moved the downloading of the install scripts before the caching.

Then I can calculate a hash of it. This hash is then added to the cache-key. Whenever a new version is beeing released the hash changes and the cache gets invalidated. This makes sure you have always installed the newest version of TeX Live.

I removed the downloading in later steps as the file is already there.